### PR TITLE
Fix error message in data fetching notebook

### DIFF
--- a/TuneWeaver.ipynb
+++ b/TuneWeaver.ipynb
@@ -294,7 +294,7 @@
     "    \"\"\"\n",
     "    if not client_id_param or client_id_param == 'YOUR_CLIENT_ID' or \\\n",
     "       not client_secret_param or client_secret_param == 'YOUR_CLIENT_SECRET':\n",
-    "        print(\"❌ Error: Spotify Client ID or Secret not properly provided to `Workspace_spotify_track_data` function.\")\n",
+    "        print(\"❌ Error: Spotify Client ID or Secret not properly provided to `fetch_spotify_track_data` function.\")\n",
     "        print(\"   Please ensure Cell 3 is correctly configured with valid credentials.\")\n",
     "        return None\n",
     "\n",


### PR DESCRIPTION
## Summary
- fix error message referencing old function name in the Spotify data collection notebook

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d55e98508331912fe4763b79f937